### PR TITLE
feat: Gestion des produits côté admin (Closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Les valeurs par défaut conviennent pour un usage de test/local.
 docker compose up -d --build
 ```
 
+En cas de problème de build :
+```bash
+docker builder prune -af # supprime tout le cache BuildKit
+docker compose up -d --build # rebuild complet
+```
+
 Cette commande :
 
 - construit l’image du backend à partir de `back/Dockerfile` ;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.13.2",
+        "jwt-decode": "^4.0.0",
         "pinia": "^3.0.4",
         "vue": "^3.5.24",
         "vue-router": "^4.6.4"
@@ -1457,6 +1458,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/magic-string": {

--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.13.2",
+    "jwt-decode": "^4.0.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.24",
     "vue-router": "^4.6.4"

--- a/front/src/api/accountApi.ts
+++ b/front/src/api/accountApi.ts
@@ -1,0 +1,12 @@
+import { http } from "./http";
+
+export type Account = {
+    id: number;
+    username: string;
+    email: string;
+};
+
+export async function getAccount(userId: number): Promise<Account> {
+    const response = await http.get(`/account/${userId}`);
+    return response.data;
+}

--- a/front/src/api/adminProductsApi.ts
+++ b/front/src/api/adminProductsApi.ts
@@ -1,0 +1,32 @@
+import { http } from './http';
+import type { ProductDTO } from '../types/dto/product';
+
+export type CreateProductPayload = {
+    code: string;
+    name: string;
+    price: number;
+    description?: string | null;
+    image?: string | null;
+    category?: string | null;
+    quantity?: number | null;
+    internalReference?: string | null;
+    shellId?: number | null;
+    inventoryStatus?: string | null;
+    rating?: number | null;
+};
+
+export type UpdateProductPayload = CreateProductPayload;
+
+export async function createProduct(payload: CreateProductPayload): Promise<ProductDTO> {
+    const response = await http.post<ProductDTO>('/products', payload);
+    return response.data;
+}
+
+export async function updateProduct(id: number, payload: UpdateProductPayload): Promise<ProductDTO> {
+    const response = await http.put<ProductDTO>(`/products/${id}`, payload);
+    return response.data;
+}
+
+export async function deleteProduct(id: number): Promise<void> {
+    await http.delete(`/products/${id}`);
+}

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -10,6 +10,7 @@ const pinia = createPinia();
 app.use(pinia);
 
 const authStore = useAuthStore();
-authStore.restoreFromLocalStorage();
-app.use(router);
-app.mount('#app');
+authStore.restoreFromLocalStorage().then(() => {
+    app.use(router);
+    app.mount('#app');
+});

--- a/front/src/stores/authStore.ts
+++ b/front/src/stores/authStore.ts
@@ -1,26 +1,54 @@
-import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import {login as loginApi} from '../api/authApi'
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import {login as loginApi} from '../api/authApi';
+import { jwtDecode } from 'jwt-decode';
+import { getAccount } from '../api/accountApi';
 
-const AUTH_TOKEN_STORAGE_KEY = 'auth.token'
+const AUTH_TOKEN_STORAGE_KEY = 'auth.token';
 
 export const useAuthStore = defineStore('auth', () => {
     const token = ref<string | null>(null);
+    const userId = ref<number | null>(null);
+    const email = ref<string | null>(null);
     const isAuthenticated = () => Boolean(token.value);
+    const isAdmin = () => { return email.value === 'admin@admin.com' };
     
     async function login(email: string, password: string) {
         const data = await loginApi(email, password);
         token.value = data.token;
+        const decoded = jwtDecode(token.value);
+        userId.value = Number(decoded.sub); //TODO: the userID in backend is uth.getName() 
         localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, data.token);
+
+        await getEmailFromToken();
     }
     
     function logout() {
         token.value = null;
+        userId.value = null;
+        email.value = null;
         localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
     }
-    function restoreFromLocalStorage() {
-        token.value = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+    async function restoreFromLocalStorage() {
+        const storedToken = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+        if (!storedToken) {
+            return;
+        }
+        token.value = storedToken;
+        
+        try {
+            const decoded = jwtDecode(storedToken);
+            userId.value = Number(decoded.sub);
+            await getEmailFromToken();
+        } catch {
+            logout();
+        }
+    }
+    
+    async function getEmailFromToken() {
+        const account = await getAccount(userId.value!);
+        email.value = account.email;
     }
 
-    return {token, isAuthenticated, login, logout, restoreFromLocalStorage}
+    return {token, isAuthenticated, isAdmin, login, logout, restoreFromLocalStorage}
 });

--- a/front/src/views/ProductDetailView.vue
+++ b/front/src/views/ProductDetailView.vue
@@ -2,6 +2,7 @@
     import { onMounted, ref, watch } from 'vue';
     import { useRoute, useRouter } from 'vue-router';
     import { getProduct } from '../api/productApi';
+    import { updateProduct, deleteProduct } from '../api/adminProductsApi';
     import type { ProductDTO } from '../types/dto/product';
     import { useCartStore } from '../stores/cartStore';
     import { useAuthStore } from '../stores/authStore';
@@ -14,6 +15,12 @@
     const loading = ref(false);
     const error = ref<string | null>(null);
     const quantity = ref(1);
+
+    const isEditing = ref(false);
+    const editForm = ref({ code: '', name: '', price: 0, description: '' });
+    const editError = ref<string | null>(null);
+    const editLoading = ref(false);
+    const deleteLoading = ref(false);
 
     const route = useRoute();
     const router = useRouter();
@@ -80,6 +87,68 @@
         await wishlistStore.toggle(product.value.id);
     }
 
+    function startEdit() {
+        if (!product.value) return;
+        editForm.value = {
+            code: product.value.code,
+            name: product.value.name,
+            price: product.value.price,
+            description: product.value.description ?? ''
+        };
+        editError.value = null;
+        isEditing.value = true;
+    }
+
+    function cancelEdit() {
+        isEditing.value = false;
+        editError.value = null;
+    }
+
+    async function submitEdit() {
+        if (!product.value) return;
+        if (!editForm.value.code || !editForm.value.name || editForm.value.price <= 0) {
+            editError.value = 'Code, nom et prix (> 0) sont obligatoires.';
+            return;
+        }
+        try {
+            editLoading.value = true;
+            editError.value = null;
+            const updated = await updateProduct(product.value.id, editForm.value);
+            product.value = updated;
+            isEditing.value = false;
+        } catch (e: any) {
+            if (e?.response?.status === 401) {
+                router.push({ name: 'login', query: { redirect: route.fullPath } });
+            } else if (e?.response?.status === 403) {
+                editError.value = 'Accès refusé : admin uniquement.';
+            } else {
+                editError.value = e?.response?.data?.message || e.message || 'Erreur lors de la modification.';
+            }
+        } finally {
+            editLoading.value = false;
+        }
+    }
+
+    async function confirmDelete() {
+        if (!product.value) return;
+        if (!confirm('Êtes-vous sûr de vouloir supprimer ce produit ?')) return;
+        try {
+            deleteLoading.value = true;
+            await deleteProduct(product.value.id);
+            router.push({ name: 'products' });
+        } catch (e: any) {
+            if (e?.response?.status === 401) {
+                router.push({ name: 'login', query: { redirect: route.fullPath } });
+            } else if (e?.response?.status === 403) {
+                error.value = 'Accès refusé : admin uniquement.';
+            } else {
+                error.value = e?.response?.data?.message || e.message || 'Erreur lors de la suppression.';
+            }
+        } finally {
+            deleteLoading.value = false;
+        }
+    }
+
 </script>
 
 <template>
@@ -123,6 +192,43 @@
                             :disabled="wishlistStore.loading"
                             @toggle="onWishlistToggle"
                         />
+                    </div>
+
+                    <div v-if="authStore.isAdmin()" class="admin-section">
+                        <h3>Administration</h3>
+                        
+                        <div v-if="!isEditing" class="admin-buttons">
+                            <button @click="startEdit" class="btn-edit">Modifier</button>
+                            <button @click="confirmDelete" :disabled="deleteLoading" class="btn-delete">
+                                {{ deleteLoading ? 'Suppression...' : 'Supprimer' }}
+                            </button>
+                        </div>
+
+                        <div v-else class="edit-form">
+                            <p v-if="editError" class="form-error">{{ editError }}</p>
+                            <label>
+                                Code
+                                <input v-model="editForm.code" type="text" />
+                            </label>
+                            <label>
+                                Nom
+                                <input v-model="editForm.name" type="text" />
+                            </label>
+                            <label>
+                                Prix
+                                <input v-model.number="editForm.price" type="number" min="0.01" step="0.01" />
+                            </label>
+                            <label>
+                                Description
+                                <textarea v-model="editForm.description" rows="3"></textarea>
+                            </label>
+                            <div class="form-buttons">
+                                <button @click="submitEdit" :disabled="editLoading">
+                                    {{ editLoading ? 'Enregistrement...' : 'Enregistrer' }}
+                                </button>
+                                <button @click="cancelEdit" type="button" class="btn-cancel">Annuler</button>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -232,6 +338,79 @@
         border: 1px solid var(--ac-border);
         background: var(--ac-surface-2);
         color: var(--ac-text);
+    }
+
+    .admin-section {
+        margin-top: clamp(16px, 2.5vw, 24px);
+        padding-top: clamp(14px, 2vw, 18px);
+        border-top: 1px solid var(--ac-border);
+    }
+
+    .admin-section h3 {
+        margin: 0 0 12px 0;
+        font-size: 1rem;
+        color: var(--ac-muted);
+    }
+
+    .admin-buttons {
+        display: flex;
+        gap: 10px;
+    }
+
+    .btn-edit {
+        background: var(--ac-primary);
+        color: white;
+    }
+
+    .btn-delete {
+        background: #c0392b;
+        color: white;
+    }
+
+    .btn-delete:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+
+    .edit-form {
+        display: grid;
+        gap: 12px;
+        max-width: 400px;
+    }
+
+    .edit-form label {
+        display: grid;
+        gap: 4px;
+        font-size: 0.9rem;
+        color: var(--ac-muted);
+    }
+
+    .edit-form input,
+    .edit-form textarea {
+        padding: 0.5rem 0.7rem;
+        border-radius: 8px;
+        border: 1px solid var(--ac-border);
+        background: var(--ac-surface-2);
+        color: var(--ac-text);
+        font-family: inherit;
+    }
+
+    .form-buttons {
+        display: flex;
+        gap: 10px;
+        margin-top: 8px;
+    }
+
+    .btn-cancel {
+        background: transparent;
+        border: 1px solid var(--ac-border);
+        color: var(--ac-muted);
+    }
+
+    .form-error {
+        color: #c0392b;
+        font-size: 0.9rem;
+        margin: 0;
     }
 </style>
 

--- a/front/src/views/ProductListView.vue
+++ b/front/src/views/ProductListView.vue
@@ -2,6 +2,7 @@
   import { onMounted, ref } from 'vue';
   import { useRoute, useRouter } from 'vue-router';
   import { getProducts } from '../api/productApi';
+  import { createProduct } from '../api/adminProductsApi';
   import type { ProductDTO } from '../types/dto/product';
   import ProductCard from '../components/ProductCard.vue';
   import ToggleButton from '../components/ToggleButton.vue';
@@ -14,6 +15,11 @@
   const page = ref(0);
   const size = ref(10);
   const totalPages = ref(0);
+
+  const showAddForm = ref(false);
+  const newProduct = ref({ code: '', name: '', price: 0 });
+  const addError = ref<string | null>(null);
+  const addLoading = ref(false);
 
   const route = useRoute();
   const router = useRouter();
@@ -60,11 +66,71 @@
     page.value += 1;
     await loadProducts();
   }
+
+  function openAddForm() {
+    newProduct.value = { code: '', name: '', price: 0 };
+    addError.value = null;
+    showAddForm.value = true;
+  }
+
+  function cancelAddForm() {
+    showAddForm.value = false;
+    addError.value = null;
+  }
+
+  async function submitNewProduct() {
+    if (!newProduct.value.code || !newProduct.value.name || newProduct.value.price <= 0) {
+      addError.value = 'Code, nom et prix (> 0) sont obligatoires.';
+      return;
+    }
+    try {
+      addLoading.value = true;
+      addError.value = null;
+      await createProduct(newProduct.value);
+      showAddForm.value = false;
+      await loadProducts();
+    } catch (e: any) {
+      if (e?.response?.status === 401) {
+        router.push({ name: 'login', query: { redirect: route.fullPath } });
+      } else if (e?.response?.status === 403) {
+        addError.value = 'Accès refusé : admin uniquement.';
+      } else {
+        addError.value = e?.response?.data?.message || e.message || 'Erreur lors de la création.';
+      }
+    } finally {
+      addLoading.value = false;
+    }
+  }
 </script>
 
 <template>
   <div>
     <h1>Product List</h1>
+
+    <div v-if="authStore.isAdmin()" class="admin-actions">
+      <button v-if="!showAddForm" @click="openAddForm" class="btn-add">Ajouter un produit</button>
+      
+      <div v-if="showAddForm" class="add-form">
+        <h2>Nouveau produit</h2>
+        <p v-if="addError" class="form-error">{{ addError }}</p>
+        <label>
+          Code
+          <input v-model="newProduct.code" type="text" placeholder="CODE001" />
+        </label>
+        <label>
+          Nom
+          <input v-model="newProduct.name" type="text" placeholder="Nom du produit" />
+        </label>
+        <label>
+          Prix
+          <input v-model.number="newProduct.price" type="number" min="0.01" step="0.01" />
+        </label>
+        <div class="form-buttons">
+          <button @click="submitNewProduct" :disabled="addLoading">Créer</button>
+          <button @click="cancelAddForm" type="button" class="btn-cancel">Annuler</button>
+        </div>
+      </div>
+    </div>
 
     <p v-if="error">{{ error }}</p>
 
@@ -181,5 +247,63 @@
   .pagination button:disabled {
     opacity: 0.55;
     cursor: not-allowed;
+  }
+
+  .admin-actions {
+    margin-bottom: clamp(14px, 2vw, 20px);
+    padding: clamp(12px, 2vw, 16px);
+    background: var(--ac-surface);
+    border: 1px solid var(--ac-border);
+    border-radius: clamp(10px, 1.2vw, 14px);
+  }
+
+  .btn-add {
+    background: var(--ac-primary);
+    color: white;
+    font-weight: 600;
+  }
+
+  .add-form {
+    display: grid;
+    gap: 12px;
+    max-width: 400px;
+  }
+
+  .add-form h2 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+
+  .add-form label {
+    display: grid;
+    gap: 4px;
+    font-size: 0.9rem;
+    color: var(--ac-muted);
+  }
+
+  .add-form input {
+    padding: 0.5rem 0.7rem;
+    border-radius: 8px;
+    border: 1px solid var(--ac-border);
+    background: var(--ac-surface-2);
+    color: var(--ac-text);
+  }
+
+  .form-buttons {
+    display: flex;
+    gap: 10px;
+    margin-top: 8px;
+  }
+
+  .btn-cancel {
+    background: transparent;
+    border: 1px solid var(--ac-border);
+    color: var(--ac-muted);
+  }
+
+  .form-error {
+    color: #c0392b;
+    font-size: 0.9rem;
+    margin: 0;
   }
 </style>


### PR DESCRIPTION
- Implémentation de `adminProductsApi` avec les fonctions `createProduct`, `updateProduct`, et `deleteProduct`.
- Ajout d'une section administration dans les vues produit (`ProductDetailView`, `ProductListView`) accessible uniquement aux admins.
- Gestion des formulaires pour ajouter, modifier et supprimer des produits avec des validations et feedback utilisateur.
- Intégration de la bibliothèque `jwt-decode` pour extraire les informations utilisateur depuis le token JWT.
- Adaptation du store `authStore` pour récupérer les détails du compte et déterminer si l'utilisateur est admin.
- Mise à jour des fichiers de styles et de structure pour inclure les actions admin.